### PR TITLE
#7 Ability to set up included/excluded projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/tpd/quboo/sonarplugin/dtos/IssuesWrapper.java
+++ b/src/main/java/io/tpd/quboo/sonarplugin/dtos/IssuesWrapper.java
@@ -3,6 +3,8 @@ package io.tpd.quboo.sonarplugin.dtos;
 import io.tpd.quboo.sonarplugin.pojos.Issue;
 import io.tpd.quboo.sonarplugin.pojos.Issues;
 import io.tpd.quboo.sonarplugin.util.QubooCache;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +14,8 @@ import static io.tpd.quboo.sonarplugin.QubooPlugin.QUBOO_API_VERSION;
 
 public class IssuesWrapper {
 
+  private static final Logger log = Loggers.get(IssuesWrapper.class);
+
   private List<Issue> issues;
   private String version = QUBOO_API_VERSION;
   private String sonarVersion;
@@ -20,9 +24,25 @@ public class IssuesWrapper {
     this.issues = new ArrayList<>();
   }
 
-  public void filterAndAddIssues(final Issues issues, final String sonarVersion) {
+  public void filterAndAddIssues(final Issues issues,
+                                 final List<String> selectedProjects,
+                                 final List<String> excludedProjects,
+                                 final String sonarVersion) {
+    log.info("Quboo project filters - Included: {} | Excluded: {}",
+      selectedProjects, excludedProjects);
     this.issues.addAll(
-      issues.getIssues().stream().filter(issue -> !QubooCache.INSTANCE.inCache(issue)).collect(Collectors.toList())
+      issues.getIssues().stream()
+        .filter(issue -> issue.getProject() == null ||
+          selectedProjects == null || selectedProjects.isEmpty() ||
+          selectedProjects.contains(issue.getProject())
+        )
+        .filter(issue -> issue.getProject() == null ||
+          (selectedProjects != null && !selectedProjects.isEmpty()) ||
+          excludedProjects == null || excludedProjects.isEmpty() ||
+          !excludedProjects.contains(issue.getProject())
+        )
+        .filter(issue -> !QubooCache.INSTANCE.inCache(issue))
+        .collect(Collectors.toList())
     );
     this.sonarVersion = sonarVersion;
   }

--- a/src/main/java/io/tpd/quboo/sonarplugin/hooks/QubooSensor.java
+++ b/src/main/java/io/tpd/quboo/sonarplugin/hooks/QubooSensor.java
@@ -20,16 +20,22 @@ public class QubooSensor implements Sensor {
 
   @Override
   public void execute(final SensorContext context) {
-    final Optional<String> key = context.config().get(QubooProperties.ACCESS_KEY);
-    final Optional<String> secret = context.config().get(QubooProperties.SECRET_KEY);
-    final Optional<String> token = context.config().get(QubooProperties.TOKEN_KEY);
-    key.ifPresent(accessKey -> context.addContextProperty(QubooProperties.ACCESS_KEY, accessKey));
-    secret.ifPresent(s -> context.addContextProperty(QubooProperties.SECRET_KEY, s));
-    token.ifPresent(s -> context.addContextProperty(QubooProperties.TOKEN_KEY, s));
-    if (key.isPresent() && key.get().equals(QubooProperties.DEFAULT_ACCESS_KEY)) {
+    toContextPropertyIfPresent(context, QubooProperties.ACCESS_KEY);
+    toContextPropertyIfPresent(context, QubooProperties.SECRET_KEY);
+    toContextPropertyIfPresent(context, QubooProperties.TOKEN_KEY);
+    toContextPropertyIfPresent(context, QubooProperties.SELECTED_PROJECTS_KEY);
+    toContextPropertyIfPresent(context, QubooProperties.REJECTED_PROJECTS_KEY);
+    Optional<String> accessKeyOptional = context.config().get(QubooProperties.ACCESS_KEY);
+    if (accessKeyOptional.isPresent() && accessKeyOptional.get().equals(QubooProperties.DEFAULT_ACCESS_KEY)) {
       log.warn("WARNING: Quboo will ignore this analysis because you haven't set the Quboo Access (and Secret) Keys. Go to your Sonarqube server (as admin), Administration -> Configuration -> Quboo and enter the values you find in your Quboo account settings.");
     } else {
-      log.info("Access key is " + key.orElse("NOT PRESENT"));
+      log.info("Access key is " + accessKeyOptional.orElse("NOT PRESENT"));
     }
+  }
+
+  private static void toContextPropertyIfPresent(final SensorContext context,
+                                                 final String propertyName) {
+    context.config().get(propertyName).ifPresent(p ->
+      context.addContextProperty(propertyName, p));
   }
 }

--- a/src/main/java/io/tpd/quboo/sonarplugin/settings/QubooProperties.java
+++ b/src/main/java/io/tpd/quboo/sonarplugin/settings/QubooProperties.java
@@ -34,6 +34,8 @@ public class QubooProperties {
   public static final String DEFAULT_ACCESS_KEY = "your-access-key";
   public static final String DEFAULT_SECRET_KEY = "your-secret-key";
   public static final String CATEGORY = "Quboo";
+  public static final String SELECTED_PROJECTS_KEY = "sonar.quboo.selected-projects";
+  public static final String REJECTED_PROJECTS_KEY = "sonar.quboo.rejected-projects";
 
   private QubooProperties() {
     // only statics
@@ -46,6 +48,7 @@ public class QubooProperties {
         .description("Your organization account access key to export report summary to Quboo")
         .defaultValue(DEFAULT_ACCESS_KEY)
         .category(CATEGORY)
+        .subCategory("Account Keys")
         .index(1)
         .build(),
       PropertyDefinition.builder(SECRET_KEY)
@@ -53,15 +56,38 @@ public class QubooProperties {
         .description("Your organization account secret key to export report summary to Quboo")
         .defaultValue(DEFAULT_SECRET_KEY)
         .category(CATEGORY)
+        .subCategory("Account Keys")
         .index(2)
         .build(),
       PropertyDefinition.builder(TOKEN_KEY)
         .name("API Token")
         .description("You need to enter a valid API token if your SonarQube server requires authentication")
         .defaultValue("")
-        .category(CATEGORY)
+        .subCategory("Secured servers")
         .type(PropertyType.PASSWORD)
         .index(3)
+        .build(),
+      PropertyDefinition.builder(SELECTED_PROJECTS_KEY)
+        .name("Selected projects")
+        .description("If you want to select the Sonarqube projects that should be processed by Quboo, enter here" +
+          " their project names separated by commas, for example: my-project-1,my-project-2. Leave it empty" +
+          " to include all projects.")
+        .defaultValue("")
+        .category(CATEGORY)
+        .type(PropertyType.STRING)
+        .subCategory("Filters")
+        .index(4)
+        .build(),
+      PropertyDefinition.builder(REJECTED_PROJECTS_KEY)
+        .name("Excluded projects")
+        .description("If you want to exclude Sonarqube projects from Quboo, enter here" +
+          " their project names separated by commas, for example: my-project-3,my-project-4. Leave it empty" +
+          " to include all projects. Note: If you're using the 'Selected projects' list, this list has no effect.")
+        .defaultValue("")
+        .category(CATEGORY)
+        .subCategory("Filters")
+        .type(PropertyType.STRING)
+        .index(5)
         .build()
     );
   }

--- a/src/test/java/io/tpd/quboo/sonarplugin/dtos/IssuesWrapperTest.java
+++ b/src/test/java/io/tpd/quboo/sonarplugin/dtos/IssuesWrapperTest.java
@@ -1,0 +1,121 @@
+package io.tpd.quboo.sonarplugin.dtos;
+
+import io.tpd.quboo.sonarplugin.pojos.Issue;
+import io.tpd.quboo.sonarplugin.pojos.Issues;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IssuesWrapperTest {
+
+  private IssuesWrapper w;
+
+  @Before
+  public void setup() {
+    w = new IssuesWrapper();
+  }
+
+  @Test
+  public void issueWithoutProjectIncluded() {
+    Issues issues = buildIssuesWithProjects(null, null);
+    List<String> selected = projects("project1");
+    List<String> rejected = projects("project2");
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).hasSize(2);
+  }
+
+  @Test
+  public void issueWithNoMatchIncluded() {
+    Issues issues = buildIssuesWithProjects("project3");
+    List<String> selected = projects();
+    List<String> rejected = projects("project2");
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).hasSize(1);
+  }
+
+  @Test
+  public void issueWithSelectedMatchIncluded() {
+    Issues issues = buildIssuesWithProjects("project1");
+    List<String> selected = projects("project1");
+    List<String> rejected = projects("project3");
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).hasSize(1);
+  }
+
+  @Test
+  public void issueWithNoSelectedMatchExcluded() {
+    Issues issues = buildIssuesWithProjects("project2");
+    List<String> selected = projects("project1");
+    List<String> rejected = projects();
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).isEmpty();
+  }
+
+  @Test
+  public void issueWithDoubleMatchNotExcluded() {
+    Issues issues = buildIssuesWithProjects("project1");
+    List<String> selected = projects("project1");
+    List<String> rejected = projects("project1");
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).hasSize(1);
+  }
+
+  @Test
+  public void allIssuesIncludedWithEmptyFilters() {
+    Issues issues = buildIssuesWithProjects("project1", null, "project2", "project3");
+    List<String> selected = projects();
+    List<String> rejected = projects();
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).hasSize(4);
+  }
+
+  @Test
+  public void multipleExcluded() {
+    Issues issues = buildIssuesWithProjects("project1", null, "project2", "project3");
+    List<String> selected = projects();
+    List<String> rejected = projects("project1", "project3");
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).extracting("project").containsExactlyInAnyOrder(null, "project2");
+  }
+
+  @Test
+  public void bothFilters1() {
+    Issues issues = buildIssuesWithProjects("project1", null, "project2", "project3", "project5");
+    List<String> selected = projects("project2");
+    List<String> rejected = projects("project1", "project3");
+    w.filterAndAddIssues(issues, selected, rejected, null);
+
+    assertThat(w.getIssues()).extracting("project").containsExactlyInAnyOrder(null, "project2");
+  }
+
+  private List<String> projects(String... s) {
+    List<String> selected = new ArrayList<>();
+    if(s != null) {
+      selected.addAll(Arrays.asList(s));
+    }
+    return selected;
+  }
+
+  private Issues buildIssuesWithProjects(String... projects) {
+    Issues issues = new Issues();
+    issues.setIssues(new ArrayList<>());
+    for (String project : projects) {
+      Issue i = new Issue();
+      i.setProject(project);
+      issues.getIssues().add(i);
+    }
+    return issues;
+  }
+}

--- a/src/test/java/io/tpd/quboo/sonarplugin/hooks/QubooConnectorTest.java
+++ b/src/test/java/io/tpd/quboo/sonarplugin/hooks/QubooConnectorTest.java
@@ -177,15 +177,18 @@ public class QubooConnectorTest {
     final Issue issue2 = new Issue().withAssignee("player2").withResolution("closed").withDebt("1h")
       .withRule("InsufficientCoverage").withKey("issue-2").withProject("project").withAuthor("author")
       .withSeverity("major").withStatus("fixed");
-    final Paging paging = new Paging().withPageIndex(1).withPageSize(2).withTotal(3);
-    return new Issues().withIssues(Arrays.asList(issue1, issue2)).withPaging(paging);
+    final Issue issue3 = new Issue().withAssignee("player2").withResolution("closed").withDebt("1h")
+      .withRule("InsufficientCoverage").withKey("issue-2").withProject("project-x").withAuthor("author")
+      .withSeverity("major").withStatus("fixed"); // should be excluded
+    final Paging paging = new Paging().withPageIndex(1).withPageSize(3).withTotal(4);
+    return new Issues().withIssues(Arrays.asList(issue1, issue2, issue3)).withPaging(paging);
   }
 
   private Issues generateIssuesPage2() {
     final Issue issue1 = new Issue().withAssignee("player1").withResolution("open").withDebt("1h")
       .withRule("InsufficientCoverage").withKey("issue-3").withProject("project").withAuthor("author")
       .withSeverity("major").withStatus("open").withType("RELIABILITY").withTags(Lists.list("tag"));
-    final Paging paging = new Paging().withPageIndex(2).withPageSize(2).withTotal(3);
+    final Paging paging = new Paging().withPageIndex(2).withPageSize(3).withTotal(4);
     return new Issues().withIssues(Collections.singletonList(issue1)).withPaging(paging);
   }
 
@@ -246,6 +249,8 @@ public class QubooConnectorTest {
     map.put(QubooProperties.ACCESS_KEY, ACCESS_KEY_VALUE);
     map.put(QubooProperties.SECRET_KEY, SECRET_KEY_VALUE);
     map.put(QubooProperties.TOKEN_KEY, TOKEN_VALUE);
+    map.put(QubooProperties.SELECTED_PROJECTS_KEY, "");
+    map.put(QubooProperties.REJECTED_PROJECTS_KEY, "project-y, project-x");
     return map;
   }
 

--- a/src/test/java/io/tpd/quboo/sonarplugin/settings/QubooPropertiesTest.java
+++ b/src/test/java/io/tpd/quboo/sonarplugin/settings/QubooPropertiesTest.java
@@ -15,9 +15,10 @@ public class QubooPropertiesTest {
   public void allPropertiesConfigured() {
     final List<PropertyDefinition> properties = QubooProperties.getProperties();
 
-    assertThat(properties.size()).isEqualTo(3);
+    assertThat(properties.size()).isEqualTo(5);
     assertThat(properties.stream().map(PropertyDefinition::key).collect(Collectors.toList()))
-      .containsExactly(QubooProperties.ACCESS_KEY, QubooProperties.SECRET_KEY, QubooProperties.TOKEN_KEY);
+      .containsExactly(QubooProperties.ACCESS_KEY, QubooProperties.SECRET_KEY, QubooProperties.TOKEN_KEY,
+        QubooProperties.SELECTED_PROJECTS_KEY, QubooProperties.REJECTED_PROJECTS_KEY);
     assertThat(properties.get(2).type()).isEqualTo(PropertyType.PASSWORD);
   }
 }


### PR DESCRIPTION
Adds two new Sonarqube plugin configuration settings that allow users to include/exclude projects selectively.